### PR TITLE
handle schema merge, delete and overwrite

### DIFF
--- a/src/dicom_to_delta.py
+++ b/src/dicom_to_delta.py
@@ -30,12 +30,6 @@ def create_delta_table(df, table_name, delta_path, merge, purge):
 			.mode("append") \
 			.save(delta_path)
 
-	# create table in metastore
-	df.repartition(1) \
-		.write \
-		.format("delta") \
-		.mode("overwrite") \
-		.saveAsTable(table_name)
 
 
 def clean_up(spark, table_name, delta_path):
@@ -51,7 +45,6 @@ def clean_up(spark, table_name, delta_path):
 	spark.conf.set("spark.databricks.delta.retentionDurationCheck.enabled", "false")
 	dt.vacuum(0) # vacuum all data
 	
-	spark.sql("DROP TABLE IF EXISTS " + table_name)
 
 
 def write_to_delta(spark_master, hdfs_ip ,hdfs_path, delta_table_path, merge, purge):


### PR DESCRIPTION
Added Arguments. Tested and checked in changes in DicomETLv1.2 v2.
- required: spark, hdfs, read, write
- optional: merge, purge

```
usage: dicom_to_delta.py [-h] --spark SPARK --hdfs HDFS --read READ --write
                         WRITE [--merge] [--purge]

Create proxy tables from Dicom parquet files.

optional arguments:
  -h, --help     show this help message and exit
  --spark SPARK  Spark master IP
  --hdfs HDFS    HDFS IP
  --read READ    Parquet file directory to read from
  --write WRITE  Delta table write directory
  --merge        (optional) Merge schema - add new columns
  --purge        (optional) Delete all delta tables - then create new tables
```